### PR TITLE
PHP7 RC7 fix

### DIFF
--- a/Content/install.cmd
+++ b/Content/install.cmd
@@ -3,7 +3,7 @@
 mkdir Commands
 cd Commands
 
-curl -L -o PHP7x86.zip http://windows.php.net/downloads/qa/php-7.0.0RC6-nts-Win32-VC14-x86.zip
+curl -L -o PHP7x86.zip http://windows.php.net/downloads/qa/php-7.0.0RC7-nts-Win32-VC14-x86.zip
 d:\7zip\7za x PHP7x86.zip -oPHP7x86
 
 :: Create PHP.ini


### PR DESCRIPTION
Since PHP7 RC7 got released, there needs to be a new version of the package downloaded since the previous one doesn't exist anymore and the addon doesn't install it correctly.
